### PR TITLE
Also add dummy Wine64

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-packager-dummy-wine",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Install this to add a dummy wine executable to your path",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "electron-packager-dummy-wine",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Install this to add a dummy wine executable to your path",
   "main": "index.js",
   "bin": {
-    "wine": "./index.js"
+    "wine": "./index.js",
+    "wine64": "./index.js"
   },
   "scripts": {
     "test": "node index.js"


### PR DESCRIPTION
Newer versions of `electron-packager` require wine64, since the intention of this library is to dummy out the need for wine, this should be dummied out too